### PR TITLE
Added ZHMTools-src downloads for relevant versions

### DIFF
--- a/pages/rpkg.tsx
+++ b/pages/rpkg.tsx
@@ -80,6 +80,16 @@ function DownloadSrcButton({ versionId }: DownloadButtonProps) {
     )
 }
 
+function DownloadZHMToolsButton({ versionId }: DownloadButtonProps) {
+    return (
+        <Link href={`https://github.com/glacier-modding/RPKG-Tool/releases/download/v${versionId}/ZHMTools-src.zip`}>
+            <Button variant={"contained"} color={"primary"}>
+                Download ZHMTools Source
+            </Button>
+        </Link>
+    )
+}
+
 export async function getStaticProps() {
     // we should probably check why these 2 constants need to
     // be out of hooks
@@ -196,7 +206,7 @@ export default function Rpkg({ allVersions }) {
                             </AccordionSummary>
                             <AccordionDetails className="changelog">
                                 <div>
-                                    <p>Released {v.date}.</p>
+                                    <p>Released {v.date}</p>
                                     <div
                                         dangerouslySetInnerHTML={{
                                             __html: v.changelog,
@@ -207,6 +217,7 @@ export default function Rpkg({ allVersions }) {
                             <AccordionActions>
                                 <DownloadButton versionId={v.id} />
                                 <DownloadSrcButton versionId={v.id} />
+                                {v.zhmtools && <DownloadZHMToolsButton versionId={v.id} />}
                             </AccordionActions>
                         </Accordion>
                     ))}

--- a/src/RpkgVersions.tsx
+++ b/src/RpkgVersions.tsx
@@ -4,6 +4,7 @@ export interface RpkgVersion {
     id: string
     changelog: React.ReactElement
     date: string
+    zhmtools?: boolean
 }
 
 export const latest: RpkgVersion = {
@@ -117,6 +118,7 @@ export const VERSION_2_14_0: RpkgVersion = {
             </ul>
         </React.Fragment>
     ),
+    zhmtools: true,
 }
 
 export const VERSION_2_13_0: RpkgVersion = {
@@ -171,6 +173,7 @@ export const VERSION_2_13_0: RpkgVersion = {
             </ul>
         </React.Fragment>
     ),
+    zhmtools: true,
 }
 
 export const VERSION_2_12_0: RpkgVersion = {
@@ -202,6 +205,7 @@ export const VERSION_2_12_0: RpkgVersion = {
             </ul>
         </React.Fragment>
     ),
+    zhmtools: true,
 }
 
 export const VERSION_2_11_2: RpkgVersion = {


### PR DESCRIPTION
This adds downloads for ZHMTools-src for relevant versions that have their own custom version.
This allows previous builds to be successfully built and complies with GPLv3 which is what ZHMTools uses.

Also removes a `.` after the date of release since it looked a bit weird.